### PR TITLE
Fix hourly aggregation stats mismatch with drill-down view (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.5.1] - 2026-03-03
+
+### Fixed
+
+#### Hourly Aggregation Stats Mismatch with Drill-Down View
+
+Fixed a timezone handling bug where the 7-day ping history hourly bars showed incorrect success/failure counts (e.g., "Failed: 0") while the minute-level drill-down for the same hour showed the correct stats (e.g., "Failed: 5").
+
+**Root Cause:**
+The `AT TIME ZONE` conversion on the `TIMESTAMP` column (`pinged_at`) was incorrect. Using a single `AT TIME ZONE` declared the UTC timestamp as the user's local timezone instead of converting it. Additionally, `DATE_TRUNC('hour')` operated on UTC timestamptz values, splitting non-whole-hour offset timezones (like IST UTC+5:30) at the :30 minute mark instead of aligning with local hour boundaries.
+
+**Files Changed:**
+- `backend/src/config/database.js` — Added explicit `SET timezone = 'UTC'` on all pool connections for consistent TIMESTAMP handling
+- `backend/src/controllers/publicController.js` — Fixed `getAggregatedPingLogs()` to use double `AT TIME ZONE` pattern for correct local hour/day bucketing; fixed `getDrillDownPingLogs()` to explicitly convert timestamps to UTC for comparison
+
+**Fix Details:**
+- Changed `DATE_TRUNC($1, pinged_at AT TIME ZONE $3)` → `DATE_TRUNC($1, (pinged_at AT TIME ZONE 'UTC') AT TIME ZONE $3)` ensuring hour/day boundaries align with the user's local clock
+- Changed drill-down comparison from `pinged_at >= $2::timestamptz` → `pinged_at >= ($2::timestamptz AT TIME ZONE 'UTC')` ensuring the drill-down fetches the exact same pings the aggregation counted
+- Aggregated stats and drill-down stats now always match for the same time period
+
+---
+
 ## [1.5.0] - 2026-02-27
 
 ### Added

--- a/backend/src/config/database.js
+++ b/backend/src/config/database.js
@@ -13,6 +13,11 @@ const pool = new Pool({
   connectionTimeoutMillis: 2000, // Return an error after 2 seconds if connection could not be established
 });
 
+// Ensure all connections use UTC session timezone for consistent TIMESTAMP handling
+pool.on('connect', (client) => {
+  client.query("SET timezone = 'UTC'");
+});
+
 // Handle pool errors (keep this - critical for crash prevention)
 pool.on('error', (err) => {
   console.error('❌ Database pool error', err);

--- a/backend/src/controllers/publicController.js
+++ b/backend/src/controllers/publicController.js
@@ -477,15 +477,17 @@ export const getAggregatedPingLogs = async (req, res) => {
     }
 
     // Query with timezone-aware time bucketing
+    // Double AT TIME ZONE: first declares pinged_at as UTC, then converts to user's local tz
+    // This ensures DATE_TRUNC aligns hour/day boundaries with the user's local clock
     const result = await query(
       `SELECT
-        DATE_TRUNC($1, pinged_at AT TIME ZONE $3) as time_bucket,
+        DATE_TRUNC($1, (pinged_at AT TIME ZONE 'UTC') AT TIME ZONE $3) as time_bucket,
         COUNT(*) as total_pings,
         COUNT(*) FILTER (WHERE status = 'success') as successful_pings,
         COUNT(*) FILTER (WHERE status IN ('failure', 'timeout')) as failed_pings,
         AVG(response_time) as avg_response_time,
-        ((DATE_TRUNC($1, pinged_at AT TIME ZONE $3)::timestamp) AT TIME ZONE $3) as bucket_start,
-        ((DATE_TRUNC($1, pinged_at AT TIME ZONE $3)::timestamp + INTERVAL '1 ${interval}') AT TIME ZONE $3) as bucket_end,
+        (DATE_TRUNC($1, (pinged_at AT TIME ZONE 'UTC') AT TIME ZONE $3)) AT TIME ZONE $3 as bucket_start,
+        (DATE_TRUNC($1, (pinged_at AT TIME ZONE 'UTC') AT TIME ZONE $3) + INTERVAL '1 ${interval}') AT TIME ZONE $3 as bucket_end,
         ROUND(
           (COUNT(*) FILTER (WHERE status = 'success')::numeric / COUNT(*)::numeric) * 100,
           2
@@ -493,7 +495,7 @@ export const getAggregatedPingLogs = async (req, res) => {
       FROM ping_logs
       WHERE api_id = $2
         AND pinged_at >= NOW() - INTERVAL '${days} days'
-      GROUP BY DATE_TRUNC($1, pinged_at AT TIME ZONE $3)
+      GROUP BY DATE_TRUNC($1, (pinged_at AT TIME ZONE 'UTC') AT TIME ZONE $3)
       ORDER BY time_bucket ASC`,
       [interval, apiId, userTimezone]
     );
@@ -538,8 +540,8 @@ export const getDrillDownPingLogs = async (req, res) => {
         pinged_at
       FROM ping_logs
       WHERE api_id = $1
-        AND pinged_at >= $2::timestamptz
-        AND pinged_at < $3::timestamptz
+        AND pinged_at >= ($2::timestamptz AT TIME ZONE 'UTC')
+        AND pinged_at < ($3::timestamptz AT TIME ZONE 'UTC')
       ORDER BY pinged_at ASC`,
       [apiId, start, end]
     );


### PR DESCRIPTION
The 7-day ping history hourly bars showed incorrect success/failure counts while the minute-level drill-down showed correct stats. Root cause was incorrect AT TIME ZONE usage on the TIMESTAMP column causing hour buckets to misalign with user's local timezone (especially for non-whole-hour offsets like IST UTC+5:30).